### PR TITLE
parser: add support for GAME section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ A section of the same name may appear in the file multiple times. This functiona
 A section can optionally have the halt point token ```!``` following the section token ```*``` in the configuration file. This token instructs the parser to stop further parsing of the file if the section name is within context. See the examples below for a visual worked case on this feature.
 
 ### Reserved names
-There are currently two reserved names for sections:
+There are currently three reserved names for sections:
  - ```ALL``` - A catch all user-mode section that will load the modules it contains for every user-mode process.
+ - ```GAME``` - A user-mode section that will load the modules it contains for every user-mode process with a titleID prefix used for a game such as PCSE, PCSB, and so on.
  - ```KERNEL``` - A section that loads resident kernel modules on the start of taiHEN.
 
 Using the halt point ```!``` on these sections results in undefined behaviour.

--- a/src/parser.c
+++ b/src/parser.c
@@ -16,6 +16,7 @@
 
 static const char *TOKEN_ALL_SECTION = "ALL";
 static const char *TOKEN_KERNEL_SECTION = "KERNEL";
+static const char *TOKEN_GAME_SECTION = "GAME";
 
 #ifdef NO_STRING
 #include <stddef.h>
@@ -39,6 +40,18 @@ static int strcmp(const char * s1, const char * s2)
         ++s1;
         ++s2;
     }
+    return (*s1 - *s2);
+}
+
+static int strncmp(const char * s1, const char * s2, size_t count)
+{
+    while ((*s1) && (*s1 == *s2) && count != 0)
+    {
+        ++s1;
+        ++s2;
+        --count;
+    }
+    if (count == 0) return 0;
     return (*s1 - *s2);
 }
 
@@ -240,6 +253,11 @@ void taihen_config_parse(const char *input, const char *section, taihen_config_h
 
         case CONFIG_SECTION_NAME_TOKEN:
             if (strcmp(ctx.line_pos, TOKEN_ALL_SECTION) == 0 && strcmp(section, TOKEN_KERNEL_SECTION) != 0)
+            {
+                record_entries = 1;
+            }
+            else if (strcmp(ctx.line_pos, TOKEN_GAME_SECTION) == 0 && strcmp(section, TOKEN_KERNEL_SECTION) != 0 &&
+                     strlen(section) == 9 && strncmp(section, "PCS", 3) == 0 && section[3] >= 'A' && section[3] <= 'H')
             {
                 record_entries = 1;
             }


### PR DESCRIPTION
For the rationale of this: https://github.com/yifanlu/taiHEN/issues/78

This will allow to shorten config.txt a huge amount when many games are involved.